### PR TITLE
Binary printers for Uint64/128 overflow.

### DIFF
--- a/str_conv.ml
+++ b/str_conv.ml
@@ -4,6 +4,7 @@ module type UintSig = sig
   val fmt     : string
   val zero    : t
   val max_int : t
+  val bits    : int
   val of_int  : int -> t
   val to_int  : t -> int
   val add     : t -> t -> t
@@ -73,7 +74,7 @@ module Make (U : UintSig) : S with type t = U.t = struct
     if !y = U.zero then
       "0"
     else begin
-      let buffer = String.create 42 in
+      let buffer = String.create U.bits in
       let conv = "0123456789abcdef" in
       let base = U.of_int base in
       let i = ref (String.length buffer) in

--- a/uint128.ml
+++ b/uint128.ml
@@ -168,6 +168,7 @@ module Conv = Str_conv.Make(struct
   let fmt     = "ULL"
   let zero    = zero
   let max_int = max_int
+  let bits    = 128
   let of_int  = of_int
   let to_int  = to_int
   let add     = add

--- a/uint32.ml
+++ b/uint32.ml
@@ -35,6 +35,7 @@ module Conv = Str_conv.Make(struct
   let name    = "Uint32"
   let zero    = zero
   let max_int = max_int
+  let bits    = 32
   let of_int  = of_int
   let to_int  = to_int
   let add     = add

--- a/uint64.ml
+++ b/uint64.ml
@@ -39,6 +39,7 @@ module Conv = Str_conv.Make(struct
   let fmt     = "UL"
   let zero    = zero
   let max_int = max_int
+  let bits    = 64
   let of_int  = of_int
   let to_int  = to_int
   let add     = add


### PR DESCRIPTION
The buffer allocated in Str_conv.Make.to_string_base is not large enough for 64 or 128 bit values. I simply added a field to determine the appropriate (max) buffer size for each generated module.
