### PR TITLE
4.06 support

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends:
  dh-ocaml (>= 0.9),
  ocaml-findlib,
  libfindlib-ocaml-dev,
- ocaml-nox (>= 3.11)
+ ocaml-nox (>= 4.02)
 Standards-Version: 3.9.2
 Section: ocaml
 Homepage: https://forge.ocamlcore.org/projects/ocaml-uint

--- a/lib/uint.ml
+++ b/lib/uint.ml
@@ -106,17 +106,17 @@ module Str_conv : Str_conv_sig = struct
       if !y = U.zero then
         "0"
       else begin
-        let buffer = String.create U.bits in
+        let buffer = Bytes.create U.bits in
         let conv = "0123456789abcdef" in
         let base = U.of_int base in
-        let i = ref (String.length buffer) in
+        let i = ref (Bytes.length buffer) in
         while !y <> U.zero do
           let x', digit = U.divmod !y base in
           y := x';
           decr i;
-          buffer.[!i] <- conv.[U.to_int digit]
+          Bytes.set buffer !i conv.[U.to_int digit]
         done;
-        prefix ^ String.sub buffer !i (String.length buffer - !i)
+        prefix ^ Bytes.sub_string buffer !i (Bytes.length buffer - !i)
       end
 
     let to_string = to_string_base 10 ""


### PR DESCRIPTION
Fixes #14.

Note that since ocaml-uint is supposed to be in maintenance-only mode, you could also consider *not* releasing a 4.06-ready version to encourage users to switch. I'm fine with either choices.