### PR TITLE
Expose type equalities with stdint

### DIFF
--- a/lib/uint128.mli
+++ b/lib/uint128.mli
@@ -1,4 +1,4 @@
-type t
+type t = Stdint.Uint128.t
 type uint128 = t
 val zero : uint128
 val one : uint128

--- a/lib/uint16.mli
+++ b/lib/uint16.mli
@@ -1,4 +1,4 @@
-type t
+type t = Stdint.Uint16.t
 type uint16 = t
 val zero : uint16
 val one : uint16

--- a/lib/uint32.mli
+++ b/lib/uint32.mli
@@ -1,4 +1,4 @@
-type t
+type t = Stdint.Uint32.t
 type uint32 = t
 val zero : uint32
 val one : uint32

--- a/lib/uint64.mli
+++ b/lib/uint64.mli
@@ -1,4 +1,4 @@
-type t
+type t = Stdint.Uint64.t
 type uint64 = t
 val zero : uint64
 val one : uint64

--- a/lib/uint8.mli
+++ b/lib/uint8.mli
@@ -1,4 +1,4 @@
-type t
+type t = Stdint.Uint8.t
 type uint8 = t
 val zero : uint8
 val one : uint8


### PR DESCRIPTION
This allows upgrading programs using uint to stdint without breaking compatibility.

/cc @Cjen1